### PR TITLE
feat: Fedora 44 support alongside Debian/Ubuntu/macOS

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,8 +1,13 @@
 #!/bin/bash
 
 cloneRepo() {
-  # Install Git
-  sudo apt update -y && sudo apt install -y git
+  # Install Git — distro helper doesn't exist yet (git clone brings it down),
+  # so sniff the package manager inline
+  if command -v dnf >/dev/null; then
+    sudo dnf install -y git
+  else
+    sudo apt update -y && sudo apt install -y git
+  fi
 
   # Clone repository
   if [[ ! -d ~/.dotfiles ]]; then

--- a/config/samba/install
+++ b/config/samba/install
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "$HOME/.dotfiles/shell/helpers/distro"
+
 SMB_CONF_FILE="/etc/samba/smb.conf"
 
 smb_conf() {
@@ -40,14 +42,27 @@ read PASSWORD
 stty echo
 echo -e "\n"
 
-sudo apt install -y samba
+case "$DOTFILES_PKG" in
+  apt) sudo apt install -y samba ;;
+  dnf) sudo dnf install -y samba ;;
+esac
 create_smb_share
 
 # Create local SMB user
 echo -e "${PASSWORD}\n${PASSWORD}\n" | sudo smbpasswd -L -a ${USERNAME}
 # Enable the user
 sudo smbpasswd -L -e ${USERNAME}
-sudo service smbd restart
+
+# Fedora's unit is `smb`, Debian's is `smbd` — pick whichever exists
+if systemctl list-unit-files | grep -q '^smbd\.service'; then
+  sudo systemctl restart smbd
+else
+  sudo systemctl restart smb
+fi
+
+# Fedora SELinux blocks Samba from serving $HOME by default — flip the
+# persistent policy boolean so the share at path=$HOME actually works
+[ "$DOTFILES_DISTRO" = fedora ] && sudo setsebool -P samba_enable_home_dirs on
 
 # Show instructions
 exec ./map

--- a/install/composer.sh
+++ b/install/composer.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
+source "$HOME/.dotfiles/shell/helpers/distro"
+
 # Check to see if the php executable is in the user's path
 if [[ -z $(which php) ]]; then
-  sudo apt install -y php8.2 php8.2-cli php8.2-common php8.2-opcache php8.2-readline
+  case "$DOTFILES_PKG" in
+    apt) sudo apt install -y php8.3 php8.3-cli php8.3-common php8.3-opcache php8.3-readline ;;
+    dnf) sudo dnf install -y php php-cli php-common php-opcache php-readline ;;
+  esac
 fi
 
 COMPOSER_PATH="/usr/local/bin/composer"

--- a/install/desktop/install
+++ b/install/desktop/install
@@ -21,22 +21,26 @@ create-opt() {
   done
 }
 
-# Download software that may not exist in apt/flathub
-download-software() {
-  # Jetbrains Toolbox
+# Tools that ship the same artefact on every distro — extracted so each
+# per-distro download helper stays focused on the divergent bits
+download-software-portable() {
+  # Jetbrains Toolbox (tarball)
   wget "https://download.jetbrains.com/toolbox/jetbrains-toolbox-${JETBRAINS_TOOLBOX_VERSION}.tar.gz" -O /tmp/jetbrains-toolbox.tar.gz
   tar -xzvf /tmp/jetbrains-toolbox.tar.gz -C /opt/apps --strip-components=1
   rm -f /tmp/jetbrains-toolbox.tar.gz
 
+  # Navicat Premium (AppImage — needs fuse-libs on Fedora; covered by fpi-archives)
+  wget https://dn.navicat.com/download/navicat16-premium-en.AppImage -O /opt/apps/navicat.AppImage
+  chmod +x /opt/apps/navicat.AppImage
+}
+
+# Debian/Ubuntu/Mint .deb + apt repo setup
+download-software-apt() {
   # 1Password
   wget https://downloads.1password.com/linux/debian/amd64/stable/1password-latest.deb -O /tmp/1password-latest.deb
 
   # Steam
   wget https://cdn.akamai.steamstatic.com/client/installer/steam.deb -O /tmp/steam.deb
-
-  # Navicat Premium
-  wget https://dn.navicat.com/download/navicat16-premium-en.AppImage -O /opt/apps/navicat.AppImage
-  chmod +x /opt/apps/navicat.AppImage
 
   # Table Plus
   wget -qO - https://deb.tableplus.com/apt.tableplus.com.gpg.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/tableplus-archive.gpg > /dev/null
@@ -48,8 +52,7 @@ download-software() {
   # asciinema
   sudo apt-add-repository -y ppa:zanchey/asciinema
 
-  # FirefoxPWA
-  # https://github.com/filips123/PWAsForFirefox
+  # FirefoxPWA — https://github.com/filips123/PWAsForFirefox
   curl -fsSL https://packagecloud.io/filips/FirefoxPWA/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/firefoxpwa-keyring.gpg > /dev/null
   echo "deb [signed-by=/usr/share/keyrings/firefoxpwa-keyring.gpg] https://packagecloud.io/filips/FirefoxPWA/any any main" | sudo tee /etc/apt/sources.list.d/firefoxpwa.list > /dev/null
 
@@ -59,6 +62,62 @@ download-software() {
   sudo apt install -y tableplus wine-installer asciinema firefoxpwa
 
   rm -f /tmp/1password-latest.deb /tmp/steam.deb /tmp/anydesk.deb
+}
+
+# Fedora rpm repo + key setup. Assumes fpi-repos already enabled RPM Fusion
+# (Steam comes from rpmfusion-nonfree).
+download-software-dnf() {
+  # 1Password — official RPM repo + signing key
+  sudo rpm --import https://downloads.1password.com/linux/keys/1password.asc
+  sudo tee /etc/yum.repos.d/1password.repo > /dev/null <<'EOF'
+[1password]
+name=1Password Stable Channel
+baseurl=https://downloads.1password.com/linux/rpm/stable/$basearch
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://downloads.1password.com/linux/keys/1password.asc
+EOF
+
+  # TablePlus — official yum repo
+  sudo tee /etc/yum.repos.d/tableplus.repo > /dev/null <<'EOF'
+[tableplus]
+name=TablePlus
+baseurl=https://deb.tableplus.com/rpm/centos/8/x86_64
+enabled=1
+gpgcheck=0
+EOF
+
+  # AnyDesk — official rpm repo
+  sudo rpm --import https://keys.anydesk.com/repos/RPM-GPG-KEY
+  sudo tee /etc/yum.repos.d/anydesk.repo > /dev/null <<'EOF'
+[anydesk]
+name=AnyDesk Fedora - stable
+baseurl=https://rpm.anydesk.com/fedora/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey=https://keys.anydesk.com/repos/RPM-GPG-KEY
+EOF
+
+  # FirefoxPWA — PackageCloud's rpm bootstrap script handles repo+key
+  curl -fsSL https://packagecloud.io/install/repositories/filips/FirefoxPWA/script.rpm.sh | sudo bash
+
+  # Install everything in one go — Steam from RPM Fusion, asciinema/wine from default repos
+  sudo dnf install -y 1password tableplus anydesk firefoxpwa steam asciinema wine
+
+  # KDE Spin gets kdeconnectd (Workstation users get the GNOME flatpak equivalent)
+  case "${XDG_CURRENT_DESKTOP:-}" in
+    *KDE*) sudo dnf install -y kdeconnectd ;;
+  esac
+}
+
+# Download software that may not exist in apt/flathub
+download-software() {
+  download-software-portable
+  case "$DOTFILES_PKG" in
+    apt) download-software-apt ;;
+    dnf) download-software-dnf ;;
+  esac
 }
 
 install-flathub-packages() {

--- a/install/desktop/install
+++ b/install/desktop/install
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-if [ "$(uname)" != "Linux" ]; then
+source "$HOME/.dotfiles/shell/helpers/distro"
+
+if [ "$DOTFILES_OS" != linux ]; then
   echo "Installer can only be run on Linux"
   exit
 fi
 
 JETBRAINS_TOOLBOX_VERSION="3.4.3.81140"
 ANYDESK_VERSION="6.3.0-1"
-OS_NAME=$(grep 'NAME=' /etc/os-release | head -1 | awk -F'"' '{print $2}')
 
 sudo -v
 
@@ -81,8 +82,120 @@ install-autostarts() {
   sed -i 's/Exec=solaar/Exec=flatpak run io.github.pwr_solaar.solaar/' "$SOLARR_AUTOSTART"
 }
 
+# ----------------------------------------------------------------------------
+# Fedora-only post-install — RPM Fusion, flathub, codecs, firmware, NVIDIA.
+# Mirrors https://github.com/devangshekhawat/Fedora-44-Post-Install-Guide
+# Each fpi-* step is idempotent; the entry point calls them in order.
+# ----------------------------------------------------------------------------
+
+# 1. RPM Fusion (free + nonfree) + Terra (third-party packages)
+fpi-repos() {
+  sudo dnf install -y \
+    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
+    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
+  sudo dnf install -y --nogpgcheck \
+    --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release
+  sudo dnf group upgrade -y core
+}
+
+# 2. System update + firmware (fwupdmgr is a no-op in VMs)
+fpi-update() {
+  sudo dnf -y update
+  fwupdmgr refresh --force || true
+  fwupdmgr update -y --no-reboot-check || true
+}
+
+# 3. Flathub remote — install-flathub-packages below depends on this
+fpi-flathub() {
+  flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+}
+
+# 4. Media codecs + ffmpeg swap (replaces ffmpeg-free with full ffmpeg)
+fpi-codecs() {
+  sudo dnf4 group install -y multimedia
+  sudo dnf swap -y 'ffmpeg-free' 'ffmpeg' --allowerasing
+  sudo dnf update -y @multimedia --setopt="install_weak_deps=False" \
+    --exclude=PackageKit-gstreamer-plugin
+  sudo dnf group install -y sound-and-video
+}
+
+# 5. VA-API hardware video accel (Intel default; AMD-only swap fails harmlessly)
+fpi-vaapi() {
+  sudo dnf install -y ffmpeg-libs libva libva-utils
+  sudo dnf swap -y libva-intel-media-driver intel-media-driver --allowerasing || true
+  sudo dnf install -y mesa-va-drivers-freeworld
+}
+
+# 6. Firefox OpenH264 (WebRTC, video calls)
+fpi-openh264() {
+  sudo dnf install -y openh264 gstreamer1-plugin-openh264 mozilla-openh264
+  sudo dnf config-manager setopt fedora-cisco-openh264.enabled=1
+}
+
+# 7. Archive support + AppImage fuse runtime (Navicat needs fuse-libs)
+fpi-archives() {
+  sudo dnf install -y unzip p7zip p7zip-plugins unrar fuse-libs
+}
+
+# 8. NVIDIA — auto-detect hardware; branch on secure-boot.
+# If MOK enrollment is needed, exits early with a copy-paste resume command
+# the user can run after reboot — no full installscript re-run required.
+fpi-nvidia() {
+  lspci | grep -qi 'vga.*nvidia\|3d.*nvidia' || return 0   # no NVIDIA, no-op
+
+  echo "NVIDIA GPU detected"
+  local sb_state
+  sb_state=$(mokutil --sb-state 2>/dev/null || echo "SecureBoot disabled")
+
+  if echo "$sb_state" | grep -qi 'enabled' \
+     && [ ! -f /etc/pki/akmods/certs/public_key.der ]; then
+    echo "Secure Boot is enabled — installing MOK signing prereqs"
+    sudo dnf install -y kmodtool akmods mokutil openssl
+    sudo kmodgenca -a
+    sudo mokutil --import /etc/pki/akmods/certs/public_key.der
+    cat <<'EOF'
+
+============================================================
+REBOOT REQUIRED to complete MOK enrollment.
+On reboot, the UEFI MOK Manager prompts you to enroll the new
+key: "Enroll MOK" -> "Continue" -> enter the password you set.
+
+Then resume the NVIDIA install with:
+
+    source ~/.dotfiles/shell/helpers/distro \
+      && source ~/.dotfiles/install/desktop/install \
+      && fpi-nvidia
+
+============================================================
+EOF
+    return 0
+  fi
+
+  sudo dnf install -y akmod-nvidia xorg-x11-drv-nvidia-cuda
+  echo "akmod will build the kernel module in the background — verify in a few minutes with:"
+  echo "    modinfo -F version nvidia"
+}
+
+# 9. Boot tidy — disable network-wait (delays boot if not connected)
+fpi-boot-tidy() {
+  sudo systemctl disable NetworkManager-wait-online.service || true
+}
+
+fedora-post-install() {
+  fpi-repos
+  fpi-update
+  fpi-flathub
+  fpi-codecs
+  fpi-vaapi
+  fpi-openh264
+  fpi-archives
+  fpi-nvidia
+  fpi-boot-tidy
+}
+
 # Run the desktop installer
 create-opt
+[ "$DOTFILES_DISTRO" = fedora ] && fedora-post-install
 download-software
 install-flathub-packages
 install-autostarts

--- a/installscript
+++ b/installscript
@@ -2,6 +2,7 @@
 
 # Load helper functions
 source "$HOME/.dotfiles/shell/helpers/helpers"
+source "$HOME/.dotfiles/shell/helpers/distro"
 
 OS="$(uname)"
 wsl2=0
@@ -60,11 +61,11 @@ detect_wsl() {
 install_zsh() {
   echo "Installing zsh"
   echo "--------------------"
-  if [[ "$OS" == "Linux" ]]; then
-    sudo apt install -y zsh
-  elif [[ "$OS" == "Darwin" ]]; then
-    brew install zsh
-  fi
+  case "$DOTFILES_PKG" in
+    apt)  sudo apt install -y zsh ;;
+    dnf)  sudo dnf install -y zsh ;;
+    brew) brew install zsh ;;
+  esac
 
   echo "Installing ohmyzsh"
   echo "--------------------"
@@ -173,19 +174,29 @@ install_python() {
 
   # Install Python build dependencies
   # https://github.com/pyenv/pyenv/wiki#suggested-build-environment
-  if [[ $(uname) == "Linux" ]]; then
-    # Ensure that OpenSSL v1.1 is not installed via Brew
-    # as this will cause Python 3.10 install to fail
-    brew uninstall --ignore-dependencies --force openssl@1.1
+  case "$DOTFILES_PKG" in
+    apt)
+      # OpenSSL v1.1 from brew conflicts with Python 3.10 build on Linux
+      brew uninstall --ignore-dependencies --force openssl@1.1 2>/dev/null || true
 
-    sudo apt update -y && sudo apt install -y \
-      make build-essential libssl-dev zlib1g-dev \
-      libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
-      libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
-      python3.10-dev openssl
-  elif [[ $(uname) == "Darwin" ]]; then
-    brew install openssl readline sqlite3 xz zlib tcl-tk
-  fi
+      sudo apt update -y
+      sudo apt install -y \
+        make build-essential libssl-dev zlib1g-dev \
+        libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+        libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev \
+        python3.10-dev openssl
+      ;;
+    dnf)
+      sudo dnf install -y \
+        @development-tools openssl-devel zlib-devel \
+        bzip2-devel readline-devel sqlite-devel wget curl llvm \
+        ncurses-devel xz xz-devel tk-devel libxml2-devel xmlsec1-devel libffi-devel \
+        openssl
+      ;;
+    brew)
+      brew install openssl readline sqlite3 xz zlib tcl-tk
+      ;;
+  esac
 
   pyenv install 2.7
   pyenv install 3.10
@@ -214,9 +225,16 @@ install_wslu() {
   fi
 
   # https://github.com/wslutilities/wslu
-  sudo add-apt-repository -y ppa:wslutilities/wslu
-  sudo apt update -y
-  sudo apt install -y wslu
+  case "$DOTFILES_PKG" in
+    apt)
+      sudo add-apt-repository -y ppa:wslutilities/wslu
+      sudo apt update -y
+      sudo apt install -y wslu
+      ;;
+    dnf)
+      sudo dnf install -y wslu
+      ;;
+  esac
 
   [ ! -f /usr/local/bin/xdg-open ] && sudo ln -s /usr/bin/wslview /usr/local/bin/xdg-open
 
@@ -281,36 +299,28 @@ install_docker() {
   if [[ "$docker" -eq 1 ]]; then
     echo "Install Docker"
 
-    # Not running in WSL 2
-    if [[ "$wsl2" -eq 0 ]]; then
-      sudo apt install -y docker.io docker-doc
-    else
-      SYS_VERS=$(grep VERSION_ID /etc/os-release | awk -F'"' '{print $2}')
-
-      echo "-----------------------------------------------"
-      echo "Installing Docker in WSL 2"
-      echo "Ensure to select 'iptables-legacy' when prompted"
-      echo "-----------------------------------------------"
-
-      # Enable systemd
-      if [ ! -f /etc/wsl.conf ]; then
-        cat <<EOF | sudo tee /etc/wsl.conf
+    # WSL 2 prep: enable systemd
+    if [[ "$wsl2" -eq 1 ]] && [ ! -f /etc/wsl.conf ]; then
+      cat <<EOF | sudo tee /etc/wsl.conf
 [boot]
 systemd=true
 EOF
-      fi
+    fi
 
-      # https://nickjanetakis.com/blog/install-docker-in-wsl-2-without-docker-desktop
-      # https://dev.to/bowmanjd/install-docker-on-windows-wsl-without-docker-desktop-34m9
-      curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
-      sudo bash /tmp/get-docker.sh
+    # Upstream installer handles both apt and dnf distros, including
+    # repo setup and signing keys. Replaces the previous apt-only path.
+    # https://docs.docker.com/engine/install/
+    curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+    sudo bash /tmp/get-docker.sh
+    rm -f /tmp/get-docker.sh
 
+    # Ubuntu 22.04 + WSL 2 needs iptables-legacy. Fedora uses nftables; never needed.
+    if [[ "$wsl2" -eq 1 ]] && [ "$DOTFILES_DISTRO" = debian ]; then
+      SYS_VERS=$(grep VERSION_ID /etc/os-release | awk -F'"' '{print $2}')
       if [[ "$SYS_VERS" == "22.04" ]]; then
         echo -e "\033[0;33mEnsure to select 'iptables-legacy' when prompted\033[0m"
         sudo update-alternatives --config iptables
       fi
-
-      rm -f /tmp/get-docker.sh
     fi
 
     # Install docker-compose
@@ -379,10 +389,17 @@ run_installer() {
   run_preinstall
 
   # Install utils (Linux)
-  if [[ "$OS" == "Linux" ]]; then
-    sudo apt update -y && sudo apt install -y \
-      build-essential curl file git wget vim curl jq zip unzip zstd xclip
-  fi
+  case "$DOTFILES_PKG" in
+    apt)
+      sudo apt update -y
+      sudo apt install -y \
+        build-essential curl file git wget vim jq zip unzip zstd xclip
+      ;;
+    dnf)
+      sudo dnf install -y \
+        @development-tools curl file git wget vim jq zip unzip zstd xclip wl-clipboard
+      ;;
+  esac
 
   #sudo apt install -y linux-headers-$(uname -r) dnsutils
 

--- a/shell/aliases/docker.sh
+++ b/shell/aliases/docker.sh
@@ -16,11 +16,12 @@ docker-backup() {
 }
 
 docker-bench() {
-  DSRV="/lib/systemd/system/docker.service"
   DEST="$HOME/.cache/docker-bench-security"
 
-  if [[ ! -f "$DSRV" ]]; then
-    echo "Docker is not installed to ${DSRV}"
+  # Ask systemd where docker.service lives instead of hard-coding
+  # /lib/systemd/system/ (Debian) vs /usr/lib/systemd/system/ (Fedora)
+  if ! systemctl cat docker.service &>/dev/null; then
+    echo "Docker is not installed"
     return 1
   fi
 

--- a/shell/helpers/distro
+++ b/shell/helpers/distro
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Distro/OS detection — sourced wherever the install scripts or runtime aliases
+# need to branch on package manager. No functions, just env vars.
+#
+#   DOTFILES_OS      linux | darwin
+#   DOTFILES_DISTRO  debian | fedora | darwin (family — Mint/Ubuntu collapse to debian)
+#   DOTFILES_PKG     apt | dnf | brew
+
+DOTFILES_OS=$(uname | tr '[:upper:]' '[:lower:]')
+DOTFILES_DISTRO=
+DOTFILES_PKG=
+
+if [ "$DOTFILES_OS" = darwin ]; then
+  DOTFILES_DISTRO=darwin
+  DOTFILES_PKG=brew
+elif [ -r /etc/os-release ]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  case " ${ID:-} ${ID_LIKE:-} " in
+    *" fedora "*|*" rhel "*|*" centos "*) DOTFILES_DISTRO=fedora; DOTFILES_PKG=dnf ;;
+    *" debian "*|*" ubuntu "*)             DOTFILES_DISTRO=debian; DOTFILES_PKG=apt ;;
+  esac
+fi
+
+export DOTFILES_OS DOTFILES_DISTRO DOTFILES_PKG

--- a/shell/loader
+++ b/shell/loader
@@ -44,6 +44,7 @@ source_dir ~/.dotfiles/shell/aliases
 [ -f ~/.dotfiles/shell/helpers/dotfiles ] && source ~/.dotfiles/shell/helpers/dotfiles
 [ -f ~/.dotfiles/shell/helpers/dotmod ] && source ~/.dotfiles/shell/helpers/dotmod
 [ -f ~/.dotfiles/shell/helpers/helpers ] && source ~/.dotfiles/shell/helpers/helpers
+[ -f ~/.dotfiles/shell/helpers/distro ] && source ~/.dotfiles/shell/helpers/distro
 [ -f ~/.dotfiles/shell/helpers/rust ] && source ~/.dotfiles/shell/helpers/rust
 [ -f ~/.dotfiles/shell/helpers/ai ] && source ~/.dotfiles/shell/helpers/ai
 

--- a/shell/optional-available/audio.sh
+++ b/shell/optional-available/audio.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "$HOME/.dotfiles/shell/helpers/distro"
+
 link-easyeffects() {
   CONF_DIR="$HOME/.var/app/com.github.wwmm.easyeffects/config/easyeffects"
 
@@ -26,35 +28,54 @@ install-easyeffects() {
 
   sudo -v
 
-  # Install pipewire from repository
-  sudo add-apt-repository ppa:pipewire-debian/pipewire-upstream -y
-  sudo add-apt-repository ppa:pipewire-debian/wireplumber-upstream -y
-  sudo apt update
-  sudo apt install pipewire -y
-  sudo apt upgrade -y
+  # PipeWire setup — Fedora ships it as default since F35; Debian needs a PPA
+  case "$DOTFILES_PKG" in
+    apt)
+      sudo add-apt-repository ppa:pipewire-debian/pipewire-upstream -y
+      sudo add-apt-repository ppa:pipewire-debian/wireplumber-upstream -y
+      sudo apt update
+      sudo apt install pipewire -y
+      sudo apt upgrade -y
 
-  # Install wireplumber
-  sudo apt purge pipewire-media-session -y
-  sudo apt install wireplumber -y
-  sudo apt install pipewire-pulse -y
-  sudo apt purge pulseaudio -y
-  sudo apt autoremove -y
+      # Install wireplumber
+      sudo apt purge pipewire-media-session -y
+      sudo apt install wireplumber -y
+      sudo apt install pipewire-pulse -y
+      sudo apt purge pulseaudio -y
+      sudo apt autoremove -y
 
-  # Mask pulseaudio
-  systemctl --user --now disable pulseaudio.service pulseaudio.socket
-  systemctl --user mask pulseaudio
+      # Additional packages
+      sudo apt install libldacbt-abr2 libldacbt-enc2 libspa-0.2-bluetooth pipewire-audio-client-libraries libspa-0.2-jack -y
+      ;;
+    dnf)
+      # Fedora already ships PipeWire + WirePlumber as the default audio stack
+      pactl info 2>/dev/null | grep -q PipeWire \
+        || echo "WARNING: PipeWire not active — Fedora should ship it by default"
+      ;;
+  esac
+
+  # Mask pulseaudio (no-op on Fedora — already replaced)
+  systemctl --user --now disable pulseaudio.service pulseaudio.socket 2>/dev/null || true
+  systemctl --user mask pulseaudio 2>/dev/null || true
   systemctl --user --now enable pipewire pipewire-pulse wireplumber
 
-  # Additional packages
-  sudo apt install libldacbt-abr2 libldacbt-enc2 libspa-0.2-bluetooth pipewire-audio-client-libraries libspa-0.2-jack -y
+  # xdg-desktop-portal flavour to match the active desktop — matters for
+  # screen sharing / file pickers in flatpak'd EasyEffects
+  local portal=
+  case "${XDG_CURRENT_DESKTOP:-}" in
+    *KDE*)   portal=xdg-desktop-portal-kde ;;
+    *GNOME*) portal=xdg-desktop-portal-gnome ;;
+  esac
+  if [ -n "$portal" ]; then
+    case "$DOTFILES_PKG" in
+      apt) sudo apt install --no-install-recommends -y "$portal" ;;
+      dnf) sudo dnf install -y "$portal" ;;
+    esac
+  fi
 
-  # ----------- YOU CAN REMOVE THIS PART IF YOU DON'T WANT EASYEFFECTS ----------
-
-  sudo apt install --no-install-recommends xdg-desktop-portal-gnome -y
+  # EasyEffects via flatpak — same on both distros
   flatpak install app/com.github.wwmm.easyeffects/x86_64/stable -y
   flatpak permission-reset com.github.wwmm.easyeffects
-
-  # -----------------------------------------------------------------------------
 
   echo "Installation finished. Please restart your computer."
 }


### PR DESCRIPTION
## Summary

Adds Fedora 44 (Workstation + KDE Spin) as a first-class target alongside the existing Debian/Ubuntu/macOS paths. Fedora replaces Linux Mint as the primary desktop Linux; Debian-family path stays for servers and WSL2.

- New `shell/helpers/distro` exports `DOTFILES_OS / DOTFILES_DISTRO / DOTFILES_PKG` from `/etc/os-release` — single source of truth, no per-script sniffing.
- Every package-install call site is now a plain `case "\$DOTFILES_PKG" in apt) … ;; dnf) … ;; brew) … ;; esac` — no wrapper functions, no DSL, reads top-to-bottom.
- New `fedora-post-install` in `install/desktop/install` mirrors the [Fedora-44-Post-Install-Guide](https://github.com/devangshekhawat/Fedora-44-Post-Install-Guide): RPM Fusion + Terra, dnf update + firmware, flathub, codecs + VA-API + OpenH264, archive tooling, NVIDIA auto-detect with secure-boot MOK enrollment flow, boot tidy.
- 1Password / TablePlus / AnyDesk / FirefoxPWA / Steam / asciinema / wine all get Fedora rpm-repo paths in `download-software`.
- Samba unit name auto-detected (`smb` on Fedora, `smbd` on Debian) + Fedora-only `setsebool samba_enable_home_dirs` so SELinux doesn't silently block the \$HOME share.
- `docker-bench` probes via `systemctl cat` instead of hard-coded `/lib/systemd/system/docker.service` (Fedora uses `/usr/lib/systemd`).
- Docker install now always uses upstream `get-docker.sh` (works on both apt and dnf); drops the Debian-only `docker.io` branch. Iptables-legacy fix kept but guarded as Debian-only.
- audio.sh: Fedora branch is a sanity-check no-op (PipeWire is default since F35); xdg-desktop-portal flavour picked from `\$XDG_CURRENT_DESKTOP`.
- Composer/PHP bumped from 8.2 → 8.3 on both branches.

## Why target dotfiles-improvements?

Built on top of #4 — retarget to `main` once #4 lands.

Companion issue: #5 (drop Linuxbrew on Linux in favour of dnf/apt + canonical installers).

## Test plan

- [ ] Fedora 44 Workstation VM: clone repo, run `bootstrap`; verify `zsh git fzf node python3 pyenv asdf` all resolve, `~/.zshrc` sources clean, `docker ps` works, `dnf repolist` shows rpmfusion-free/nonfree + terra, `flatpak remotes` shows flathub, `ffmpeg -version` is the full build
- [ ] Fedora 44 KDE Spin VM: same as Workstation + confirm `xdg-desktop-portal-kde` installed and screen-share works in a flatpak
- [ ] Desktop installer on Fedora: 1Password, Steam, TablePlus, AnyDesk install and launch via dnf repos
- [ ] audio.sh on Fedora: `pactl info` shows PipeWire, easyeffects flatpak opens
- [ ] Ubuntu 24.04 VM: re-run `installscript`, no regressions (same apt path)
- [ ] WSL2 Ubuntu: `install_docker` still works (most fragile path; now via get-docker.sh)
- [ ] macOS: sanity-source `installscript --ask-optional` — Darwin branch untouched
- [ ] NVIDIA host (desktop/laptop): verify auto-detect triggers, secure-boot MOK flow prints the resume command

🤖 Generated with [Claude Code](https://claude.com/claude-code)